### PR TITLE
Removed duplicated code from exemplary validations for password

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,11 +4,10 @@ class User < ActiveRecord::Base
                        :confirmation => true,
                        :length => {:within => 6..40},
                        :on => :create,
-                       :if => :password#,
-=begin                       :format => {:with => /\A.*(?=.{10,})(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[\@\#\$\%\^\&\+\=]).*\z/}
+                       :if => :password
+=begin
   validates :password, :presence => true,
                         :confirmation => true,
-                        :on => :update,
                         :if => :password,
                         :format => {:with => /\A.*(?=.{10,})(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[\@\#\$\%\^\&\+\=]).*\z/}
 =end  

--- a/app/views/layouts/tutorial/broken_auth_sess/_password_complexity.html.erb
+++ b/app/views/layouts/tutorial/broken_auth_sess/_password_complexity.html.erb
@@ -70,18 +70,11 @@
 				<li>1 special character</li>
 			  </p>	
 			  <pre class="ruby">
-			  # VALIDATE PASSWORD BOTH AT CREATION AND WHEN UPDATING	 
 			  validates :password, :presence => true,
 			                        :confirmation => true,
 			                        :length => {:within => 6..40},
-			                        :on => :create,
 			                        :if => :password,
 			                        :format => {:with => /\A.*(?=.{10,})(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[\@\#\$\%\^\&\+\=]).*\z/}
-			  validates :password, :presence => true,
-			                         :confirmation => true,
-			                         :on => :update,
-			                         :if => :password,
-			                         :format => {:with => /\A.*(?=.{10,})(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[\@\#\$\%\^\&\+\=]).*\z/}
 										
 			  </pre>	
             </div>


### PR DESCRIPTION
Validations are being run by default on save, so there's no need to duplicate the code for create and update.
