### PR TITLE
Update benefits.rb accept binary file types.

### DIFF
--- a/app/models/benefits.rb
+++ b/app/models/benefits.rb
@@ -4,7 +4,7 @@ class Benefits < ActiveRecord::Base
  def self.save(file, backup=false)
    data_path = Rails.root.join("public", "data")
    full_file_name = "#{data_path}/#{file.original_filename}"
-   f = File.open(full_file_name, "w+")
+   f = File.open(full_file_name, "wb+")
    f.write file.read
    f.close
    make_backup(file, data_path, full_file_name) if backup == "true"


### PR DESCRIPTION
The modification allows binary file types (e.g. MS word docs) to be uploaded without encountering encoding errors

When uploading with just w+ I was getting an error (below) if I uploaded a binary file type (e.g. PDF, Word)
## 

Encoding::UndefinedConversionError in BenefitFormsController#upload

"\xCC" from ASCII-8BIT to UTF-8

Rails.root: /home/railsgoat/railsgoat
Application Trace | Framework Trace | Full Trace

app/models/benefits.rb:8:in `write'
app/models/benefits.rb:8:in`save'
## app/controllers/benefit_forms_controller.rb:22:in `upload'

Some googling indicated that adding the b parameter to the call to File.open could address this.  Tried adding to a local copy and it now seems to take HTML and Word docs fine.
