### PR TITLE
Fixes #142 with dynamic Action Mailer url options

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,16 @@
 class ApplicationController < ActionController::Base
-  before_filter :authenticated, :has_info, :create_analytic
+  before_filter :authenticated, :has_info, :create_analytic, :mailer_options
   helper_method :current_user, :is_admin?, :sanitize_font
 
   # Our security guy keep talking about sea-surfing, cool story bro.
   # protect_from_forgery
 
   private
+
+  def mailer_options
+    ActionMailer::Base.default_url_options[:protocol] = request.protocol
+    ActionMailer::Base.default_url_options[:host]     = request.host_with_port
+  end
 
   def current_user
     @current_user ||= (

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,7 +28,7 @@ Railsgoat::Application.configure do
   # Log the query plan for queries taking more than this (works
   # with SQLite, MySQL, and PostgreSQL)
   config.active_record.auto_explain_threshold_in_seconds = 0.5
-  
+
   # Tired of caching causing issues
   config.middleware.delete Rack::ETag
 
@@ -41,7 +41,6 @@ Railsgoat::Application.configure do
   # ActionMailer settings for email support
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = { :address => "localhost", :port => 1025 }
-  config.action_mailer.default_url_options = { :host => "localhost:3000" }
 
   config.middleware.insert_before(
        Rack::Lock, Rack::LiveReload,


### PR DESCRIPTION
Fixes #142. I spent some time reading about Action Mailer URL generation. I'm not sure if this is the best approach (maybe it's a bit hacky?), but if I understand the issue here, this seems to resolve it. When I implemented this feature, I had to pass the `:host` parameter to `url_for`. Instead, I ended up defining `localhost:3000` in the development environment configuration.

My thought here as a possible solution is to generate the host value without defining it as a specific default. Thoughts?

**References:**
http://simonecarletti.com/blog/2009/10/actionmailer-and-host-value/
http://guides.rubyonrails.org/action_mailer_basics.html#generating-urls-in-action-mailer-views
