### PR TITLE
Remove hard version dependency for libv8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,8 +58,6 @@ gem 'turbolinks' # New for Rails 4.0
 # See https://github.com/sstephenson/execjs#readme for more supported runtimes
 # gem 'therubyracer', :platforms => :ruby
 
-gem 'libv8', '3.16.14.8' # 3.16.14.9 was yanked - temp. fix.
-
 gem 'jquery-rails'
 
 # To use ActiveModel has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,7 +155,7 @@ GEM
     kgio (2.9.3)
     launchy (2.4.3)
       addressable (~> 2.3)
-    libv8 (3.16.14.8)
+    libv8 (3.16.14.11)
     listen (3.0.1)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
@@ -343,7 +343,6 @@ DEPENDENCIES
   jquery-fileupload-rails
   jquery-rails
   launchy
-  libv8 (= 3.16.14.8)
   mailcatcher
   mysql2
   poltergeist


### PR DESCRIPTION
Version 3.16.14.8 doesn't build on OS X anymore.