### PR TITLE
Added DOS vulnerability

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -3,6 +3,8 @@ class MessagesController < ApplicationController
   def index
     @messages = current_user.messages
     @message = Message.new
+    # Blocking code can cause DOS
+    sleep(3)
   end
 
   def show


### PR DESCRIPTION
Added a sleep to the show messages page to show how using slow blocking
methods can allow DOS to occur.

See: [issues/41](https://github.com/OWASP/railsgoat/issues/41)