### PR TITLE
fixed routing error on apis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,3 +96,6 @@ gem 'mailcatcher'
 #  # bundle exec rake doc:rails generates the API under doc/api.
 #  gem 'sdoc', require: false
 #end
+
+#For Rails 4.2
+gem 'responders'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,6 +247,8 @@ GEM
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
     ref (2.0.0)
+    responders (2.1.2)
+      railties (>= 4.2.0, < 5.1)
     rspec (2.99.0)
       rspec-core (~> 2.99.0)
       rspec-expectations (~> 2.99.0)
@@ -371,6 +373,7 @@ DEPENDENCIES
   rails (= 4.2.6)
   rake (= 10.5.0)
   rb-fsevent
+  responders
   rspec-rails (= 2.99.0)
   sass-rails
   simplecov


### PR DESCRIPTION
All APIs return RoutingError on rails4.2 (e.g. GET /api/v1/users).

```
$ rails s
=> Booting Thin
=> Rails 4.2.6 application starting in development on http://localhost:3000
=> Run `rails server -h` for more startup options
=> Ctrl-C to shutdown server
>> Thin web server (v1.5.1 codename Straight Razor)
>> Maximum connections set to 1024
>> Listening on localhost:3000, CTRL+C to stop


Started GET "/api/v1/users" for 127.0.0.1 at 2016-04-11 19:01:53 +0900

ActionController::RoutingError - The controller-level `respond_to' feature has been extracted to the `responders` gem. Add it to your Gemfile to continue using this feature:
  gem 'responders', '~> 2.0'
```

According to rails upgrade guide, we need to add `responders` gem.

http://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#responders