### PR TITLE
Add docker-compose and build from ruby docker base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,9 @@
-FROM rails:onbuild
-MAINTAINER owasp
+FROM ruby:2.3.1
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
+RUN mkdir /myapp
+WORKDIR /myapp
+ADD Gemfile /myapp/Gemfile
+ADD Gemfile.lock /myapp/Gemfile.lock
+RUN bundle install
+ADD . /myapp
 
-ADD script/start /start
-
-RUN chmod a+x /start
-
-user root
-
-ENV RAILS_ENV development
-
-CMD /start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '2'
+services:
+  web:
+    build: .
+    command: bundle exec rails s -p 3000 -b '0.0.0.0'
+    volumes:
+      - .:/myapp
+    ports:
+      - "3000:3000"


### PR DESCRIPTION
In reference to #241 this uses docker-compose to build the web container and a ruby base image instead of default rails.  

Steps to build image and start container: 

1. `$ docker-compose build`
2. `$ docker-compose run web rake db:setup` 
3. `$ docker-compose up` 

Note: if your container exits with an error, it may be because a server is already running: 
```
A server is already running. Check /myapp/tmp/pids/server.pid.
=> Booting Thin
=> Rails 4.2.6 application starting in development on http://0.0.0.0:3000
=> Run `rails server -h` for more startup options
=> Ctrl-C to shutdown server
Exiting
```

In this case, remove that `server.pid` file and try again.  Note also that this file is in your current working directory, not inside the container.  
