### PR TITLE
Updated documentation to include steps to run RailsGoat with Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,35 @@ Once you see the preceeding message Railsgoat is running on your localhost on po
 
 Open your favorite browser, navigate to `http://localhost:3000` and start hacking!
 
+## Docker Install
+To run Railsgoat with Docker you must first have [Docker](https://docs.docker.com/engine/installation/) and [Docker Compose](https://docs.docker.com/compose/install/) installed. Once those dependencies are installed, cd into the Railsgoat directory where you've cloned the code and run.
+
+```
+#~/code/railsgoat
+$ docker-compose build
+$ docker-compose run web rake db:setup
+$ docker-compose up
+...
+  Creating railsgoat_web_1
+  Attaching to railsgoat_web_1
+$
+```
+Once you see the preceeding message Railsgoat is running on your localhost on port 3000.
+
+Open your favorite browser, navigate to `http://localhost:3000` and start hacking!
+
+Note: if your container exits with an error, it may be because a server is already running:
+```
+A server is already running. Check /myapp/tmp/pids/server.pid.
+=> Booting Thin
+=> Rails 4.2.6 application starting in development on
+http://0.0.0.0:3000
+=> Run `rails server -h` for more startup options
+=> Ctrl-C to shutdown server
+Exiting
+```
+In this case, remove that server.pid file and try again. Note also that this file is in your current working directory, not inside the container.
+
 ## Capybara Tests
 
 RailsGoat now includes a set of failing Capybara RSpecs, each one indicating that a separate vulnerability exists in the application. To run them, you first need to install [PhantomJS](https://github.com/jonleighton/poltergeist#installing-phantomjs), which is required by the Poltergeist Capybara driver. Upon installation, simply run the following rake task:


### PR DESCRIPTION
Taken from https://github.com/OWASP/railsgoat/pull/248 and tested on my own machine, which is running OS X.