### PR TITLE
bug(work-info): raise more useful error when key_management is missing

### DIFF
--- a/app/models/work_info.rb
+++ b/app/models/work_info.rb
@@ -26,12 +26,12 @@ class WorkInfo < ApplicationRecord
   end
 
   def key
-    raise "Key Missing" if !(KEY)
+    raise "Key Missing" unless KEY.present?
     KEY
   end
 
   def iv
-    raise "No IV for this User" if !(self.key_management.iv)
+    raise "No IV for this User" unless self.key_management.try(:iv).present?
     self.key_management.iv
   end
 


### PR DESCRIPTION
Closes #185 

@cktricky this is one of a few places where objects related to `User` don't get initialized, and so the the app behaves poorly. What do you think about using a hook on create to make sure that these records always exist?