### PR TITLE
Relocated build_benefits_data invocation

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,6 @@ class UsersController < ApplicationController
 
   def create
     user = User.new(user_params)
-    user.build_benefits_data
     if user.save
       session[:user_id] = user.user_id
       redirect_to home_dashboard_index_path

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,6 +21,7 @@ class User < ApplicationRecord
   has_many :messages, :foreign_key => :receiver_id, :primary_key => :user_id, :dependent => :destroy
   has_many :pay, :foreign_key => :user_id, :primary_key => :user_id, :dependent => :destroy
   before_create { generate_token(:auth_token) }
+	before_create :build_benefits_data
 
   def build_benefits_data
     build_retirement(POPULATE_RETIREMENTS.shuffle.first)

--- a/spec/support/user_fixture.rb
+++ b/spec/support/user_fixture.rb
@@ -11,7 +11,6 @@ class UserFixture
     def user.clear_password
       'thi$ 1s cOmplExEr'
     end
-    user.build_benefits_data
     user.save!
     user
   end


### PR DESCRIPTION
As discussed in PR #265 the `build_benefits_data` method was relocated from the users controller to the model leveraging the `before_create` method. The tests rake tests pass and I'm able to `rake db:setup` accordingly without issue.

Please PR @jmmastey. Thanks!