### PR TITLE
Crack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,6 @@ gem 'ruby-prof'
 
 gem 'sqlite3'
 gem 'foreman'
-gem 'crack', '0.4.3'
 
 # Pry for Rails, not in dev group in case running via prod/staging @ a training
 gem 'pry-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'ruby-prof'
 
 gem 'sqlite3'
 gem 'foreman'
-gem 'crack', '0.3.2'
+gem 'crack', '0.4.3'
 
 # Pry for Rails, not in dev group in case running via prod/staging @ a training
 gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,8 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
     contracts (0.16.0)
-    crack (0.3.2)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.3)
     cucumber (3.1.0)
       builder (>= 2.1.2)
@@ -270,6 +271,7 @@ GEM
     ruby-prof (0.16.2)
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
+    safe_yaml (1.0.4)
     sass (3.5.3)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -334,7 +336,7 @@ DEPENDENCIES
   bundler-audit
   capybara
   coffee-rails
-  crack (= 0.3.2)
+  crack (= 0.4.3)
   database_cleaner
   execjs
   foreman

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,8 +82,6 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
     contracts (0.16.0)
-    crack (0.4.3)
-      safe_yaml (~> 1.0.0)
     crass (1.0.3)
     cucumber (3.1.0)
       builder (>= 2.1.2)
@@ -271,7 +269,6 @@ GEM
     ruby-prof (0.16.2)
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
-    safe_yaml (1.0.4)
     sass (3.5.3)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -336,7 +333,6 @@ DEPENDENCIES
   bundler-audit
   capybara
   coffee-rails
-  crack (= 0.4.3)
   database_cleaner
   execjs
   foreman


### PR DESCRIPTION
@jasnow [wisely discovered/mentioned](https://github.com/OWASP/railsgoat/commit/bddc7803dc8a3907a97f6f7c8f9956f4c4e165c0#commitcomment-25984700) that I only upgraded to the version that did not have a CVE versus the latest version. 

Then I got to thinking... we don't even use it. So I removed it.