### PR TITLE
changed user_id to id

### DIFF
--- a/spec/vulnerabilities/command_injection_spec.rb
+++ b/spec/vulnerabilities/command_injection_spec.rb
@@ -16,7 +16,7 @@ feature "command injection" do
     legit_file = File.join(Rails.root, "public", "data", "legit.txt")
     File.open(legit_file, "w") { |f| f.puts "totes legit" }
 
-    visit "/users/#{normal_user.user_id}/benefit_forms"
+    visit "/users/#{normal_user.id}/benefit_forms"
     Dir.mktmpdir do |dir|
       hackety_file = File.join(dir, "test; cd public && cd data && rm -f * ;")
       File.open(hackety_file, "w") { |f| f.print "mwahaha" }

--- a/spec/vulnerabilities/insecure_dor_spec.rb
+++ b/spec/vulnerabilities/insecure_dor_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 
 feature "insecure direct object reference" do
   let(:normal_user) { UserFixture.normal_user }
-  let(:another_user) { User.find_by(user_id: 2) }
+  let(:another_user) { User.find_by(id: 2) }
 
   before do
     UserFixture.reset_all_users
@@ -13,7 +13,7 @@ feature "insecure direct object reference" do
   scenario "attack one" do
     login(normal_user)
 
-    visit "/users/#{normal_user.user_id}/benefit_forms"
+    visit "/users/#{normal_user.id}/benefit_forms"
     download_url = first(".widget-body a")[:href]
     visit download_url.sub(/name=(.*?)&/, "name=config/database.yml&")
 
@@ -22,9 +22,9 @@ feature "insecure direct object reference" do
   end
 
   scenario "attack two\nTutorial: https://github.com/OWASP/railsgoat/wiki/A4-Insecure-Direct-Object-Reference" do
-    expect(normal_user.user_id).not_to eq(another_user.user_id)
+    expect(normal_user.id).not_to eq(another_user.id)
 
-    visit "/users/#{another_user.user_id}/work_info"
+    visit "/users/#{another_user.id}/work_info"
 
     expect(first("td").text).not_to include(another_user.name)
     expect(first("td").text).to include(normal_user.name)

--- a/spec/vulnerabilities/mass_assignment_spec.rb
+++ b/spec/vulnerabilities/mass_assignment_spec.rb
@@ -14,11 +14,11 @@ feature "mass assignment" do
     login(normal_user)
 
     params = { user: { admin: "t",
-                        user_id: normal_user.user_id,
+                        id: normal_user.id,
                         password: normal_user.clear_password,
                         password_confirmation: normal_user.clear_password }}
 
-    page.driver.put "/users/#{normal_user.user_id}.json", params
+    page.driver.put "/users/#{normal_user.id}.json", params
 
     expect(normal_user.reload.admin).to be_falsy
   end

--- a/spec/vulnerabilities/sensitive_data_exposure.rb
+++ b/spec/vulnerabilities/sensitive_data_exposure.rb
@@ -17,7 +17,7 @@ feature "sensitive data exposure" do
   scenario "attack\nTutorial: https://github.com/OWASP/railsgoat/wiki/A6-Sensitive-Data-Exposure-Cleartext-Storage-SSNs" do
     login(normal_user)
 
-    visit "/users/#{normal_user.user_id}/work_info"
+    visit "/users/#{normal_user.id}/work_info"
 
     expect(page.source).not_to include(user_ssn)
   end

--- a/spec/vulnerabilities/sql_injection_spec.rb
+++ b/spec/vulnerabilities/sql_injection_spec.rb
@@ -15,7 +15,7 @@ feature "sql injection" do
 
     login(normal_user)
 
-    visit "/users/#{normal_user.user_id}/account_settings"
+    visit "/users/#{normal_user.id}/account_settings"
     within("#account_edit") do
       fill_in "Email", with: "joe.admin@schmoe.com"
       fill_in "user_password", with: "hacketyhack"

--- a/spec/vulnerabilities/xss_spec.rb
+++ b/spec/vulnerabilities/xss_spec.rb
@@ -13,7 +13,7 @@ feature "xss" do
   scenario "attack\nTutorial: https://github.com/OWASP/railsgoat/wiki/A3-Cross-Site-Scripting", js: true do
     login(normal_user)
 
-    visit "/users/#{normal_user.user_id}/account_settings"
+    visit "/users/#{normal_user.id}/account_settings"
     within("#account_edit") do
       fill_in "First name", with: "<script>$(function() { $('div input.btn').val('RailsGoat h4x0r3d') } )</script>"
 
@@ -25,7 +25,7 @@ feature "xss" do
 
     sleep(1)
 
-    visit "/users/#{normal_user.user_id}/account_settings"
+    visit "/users/#{normal_user.id}/account_settings"
 
 
     expect(find("#submit_button").value).not_to include("RailsGoat h4x0r3d")


### PR DESCRIPTION
Hey @jmmastey I noticed `user_id` was in use (and showed up in the error messages) so I went ahead and changed it to `id`. 