### PR TITLE
Fixed a javascript file name in app/views/pay/index.html.erb

### DIFF
--- a/app/views/pay/index.html.erb
+++ b/app/views/pay/index.html.erb
@@ -146,7 +146,7 @@
   </div>
 </div>
 
-<%= javascript_include_tag "jquery.dataTables.js" %>
+<%= javascript_include_tag "jquery.dataTables.min.js" %>
 
 <script type="text/javascript">
 


### PR DESCRIPTION
The javascript file name in app/views/pay/index.html.erb 'jquery.dataTables.js' is not consistent with the actual javascipt file in /app/assets/javascripts 'jquery.dataTables.min.js'. THis issue was breaking the table creation in "PAY" page. This commit fixes by renaming the erring line in index.html.erb