### PR TITLE
Add context to error message if encryption key is missing

### DIFF
--- a/lib/encryption.rb
+++ b/lib/encryption.rb
@@ -22,7 +22,7 @@ module Encryption
 
   # Should be able to just re-use the same key we already have!
   def self.key
-    raise "Key Missing" if !(KEY)
+    raise "Key Missing. Add one in initializers/key.rb" if !(KEY)
     KEY
   end
 


### PR DESCRIPTION
I was deploying a fresh install to Heroku and this tripped me up for 15 minutes.