### PR TITLE
Fixed Several Unit Tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -63,4 +63,11 @@ end
 
 Capybara.javascript_driver = :poltergeist
 
+# This is disabled to support testing of CSRF
+# 
+# CSRF Testing throws an InvalidAuthenticityToken exception in the event that
+# the mitigation is working, which was causing the test to fail because of the
+# uncaught exception. Disabling "raise_server_errors" seems to solve the problem
+# but may have other ramifications.
+Capybara.raise_server_errors = false
 DatabaseCleaner.strategy = :truncation

--- a/spec/vulnerabilities/insecure_dor_spec.rb
+++ b/spec/vulnerabilities/insecure_dor_spec.rb
@@ -23,6 +23,7 @@ feature "insecure direct object reference" do
 
   scenario "attack two\nTutorial: https://github.com/OWASP/railsgoat/wiki/A4-Insecure-Direct-Object-Reference" do
     expect(normal_user.id).not_to eq(another_user.id)
+    login(normal_user)
 
     visit "/users/#{another_user.id}/work_info"
 

--- a/spec/vulnerabilities/insecure_dor_spec.rb
+++ b/spec/vulnerabilities/insecure_dor_spec.rb
@@ -27,7 +27,7 @@ feature "insecure direct object reference" do
 
     visit "/users/#{another_user.id}/work_info"
 
-    expect(first("td").text).not_to include(another_user.name)
-    expect(first("td").text).to include(normal_user.name)
+    expect(first("td").text).not_to include(another_user.full_name)
+    expect(first("td").text).to include(normal_user.full_name)
   end
 end

--- a/spec/vulnerabilities/unvalidated_redirects_spec.rb
+++ b/spec/vulnerabilities/unvalidated_redirects_spec.rb
@@ -20,6 +20,7 @@ feature "unvalidated redirect" do
       click_on "Login"
     end
 
-    expect(current_url).to eq("/dashboard/home")
+    expect(current_url).to start_with("http://127.0.0.1")
+    expect(current_path).to eq("/dashboard/home")
   end
 end

--- a/spec/vulnerabilities/url_access_spec.rb
+++ b/spec/vulnerabilities/url_access_spec.rb
@@ -15,6 +15,6 @@ feature "url access" do
 
     visit "/admin/1/dashboard"
 
-    expect(current_path).to eq("/")
+    expect(current_path).to eq("/dashboard/home")
   end
 end


### PR DESCRIPTION
* Disabled Capybara's `raise_server_errors` to allow CSRF test to pass/fail approperiately.
* Fixed IDOR test to now login (previously removed) and to utilize the `.full_name` method instead of `.name`
* Changed unvalidated redirect test to compare the `current_url` to `localhost` and the `current_path` to `/dashboard/home`
* Changed the URL access test to compare the `current_path` to `/dashboard/home`