### PR TITLE
Fixed guardfile to close #321

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -23,7 +23,7 @@ guard "livereload", host: "railsgoat.dev", port: "35727" do
 end
 
 
-guard "rspec" do
+guard :rspec, cmd: 'bundle exec rspec' do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }
   watch("spec/spec_helper.rb")  { "spec" }


### PR DESCRIPTION
Switched definition of Guard task to the following format: `guard :rspec, cmd: 'bundle exec rspec' do` to close #321 