### PR TITLE
Upgrade capybara -> 3.8.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,7 @@ GEM
     bundler-audit (0.6.0)
       bundler (~> 1.2)
       thor (~> 0.18)
-    capybara (3.8.1)
+    capybara (3.8.2)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)


### PR DESCRIPTION
Update capybara to 3.8.2, which fixes negated class selector option (https://github.com/teamcapybara/capybara/issues/2103).