### PR TITLE
Update Dockerfile and Gemfile to available tagged ruby version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5.2
+FROM ruby:2.5.3
 RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
 RUN mkdir /myapp
 WORKDIR /myapp

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 #don't upgrade
 gem "rails", "5.1.6"
 
-ruby "2.5.2"
+ruby "2.5.3"
 
 gem "aruba"
 gem "bcrypt"


### PR DESCRIPTION
The docker image tagged 2.5.2 appears to be no longer available on hub.docker.io. 2.5.3 seems to work fine