### PR TITLE
Adds phantomjs to docker container PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,21 @@
 FROM ruby:2.3.3
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
-RUN mkdir /myapp
-WORKDIR /myapp
-ADD Gemfile /myapp/Gemfile
-ADD Gemfile.lock /myapp/Gemfile.lock
-RUN bundle install
-ADD . /myapp
 
+RUN apt-get update -q \
+  && apt-get install -y --no-install-recommends \
+     build-essential \
+     libpq-dev \
+     nodejs \
+     bzip2 \
+     wget \
+  && rm -rf /var/lib/apt/lists/* \
+  && mkdir /goat \
+  && wget -q https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 \
+  && bzip2 -d phantomjs-2.1.1-linux-x86_64.tar.bz2 \
+  && tar -xvf phantomjs-2.1.1-linux-x86_64.tar \
+  && ln -sf /phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs
+
+COPY . /goat
+
+WORKDIR /goat
+
+RUN bundle install


### PR DESCRIPTION
What?

Adds phantomjs to the docker container path as I was being prompted to add phantomjs to my path in the old version and now I get a list of failures (think koans) that need to be fixed when I run
`docker-compose run web rails training`

Also lints a bunch of things in the Dockerfile:
- Use COPY instead of ADD
- Don't install additional packages
- Remove package lists to make container smaller
- Renames from myapp to goat for fun

Why?

So that I can successfully complete the koans

A/C

Enables successful running of koans
