### PR TITLE
Strip whitespace from email when logging in

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -12,7 +12,7 @@ class SessionsController < ApplicationController
     path = params[:url].present? ? params[:url] : home_dashboard_index_path
     begin
       # Normalize the email address, why not
-      user = User.authenticate(params[:email].to_s.downcase, params[:password])
+      user = User.authenticate(params[:email].to_s.strip.downcase, params[:password])
     rescue RuntimeError => e
       # don't do ANYTHING
     end


### PR DESCRIPTION
Makes it a little easier to copy-paste credentials.

This has been irritating me 😅 