### PR TITLE
feat: add password minimum to placeholder text

### DIFF
--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -14,7 +14,7 @@
             <%= f.text_field :first_name, {:class => "input input-block-level", :placeholder => "First Name"} %>
             <%= f.text_field :last_name, {:class => "input input-block-level", :placeholder => "Last Name"} %>
             <div class="control-group">
-              <%= f.password_field :password, {:class => "input input-block-level", :placeholder => "Password"}%>
+              <%= f.password_field :password, {:class => "input input-block-level", :placeholder => "Password (at least six characters)"}%>
             </div>
             <div class="control-group">
                 <%= f.password_field :password_confirmation, {:class => "input input-block-level", :placeholder => "Confirm Password"}%>


### PR DESCRIPTION
RailsGoat presently requires passwords be at least 6 and not more than 40 characters in length. Entering an invalid password during sign-up resets the sign-up form, forcing a user to re-enter all of their information.

This UI change helps a user have a valid password on the first try:
![image](https://user-images.githubusercontent.com/3347571/87095678-04828680-c1f6-11ea-9caa-c91cb7dbe160.png)
