### PR TITLE
Update bundler version for docker-compose build & mimemagic gpl version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,6 @@ RUN mkdir /myapp
 WORKDIR /myapp
 ADD Gemfile /myapp/Gemfile
 ADD Gemfile.lock /myapp/Gemfile.lock
+RUN gem install bundler -v 1.17.3
 RUN bundle install
 ADD . /myapp

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,7 +182,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
-    mimemagic (0.3.3)
+    mimemagic (0.3.9)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.13.0)


### PR DESCRIPTION
The `docker-compose build` fails because the version of the bundler specified in Gemfile.lock is different from the version of the bundler running on docker.
I fixed this by specifying the bundler version in the dockerfile.

```
$ docker-compose build
Building web
[+] Building 3.8s (11/13)                                                                                                                                                              
 => [internal] load build definition from Dockerfile                                                                                                                              0.0s
 => => transferring dockerfile: 294B                                                                                                                                              0.0s
 => [internal] load .dockerignore                                                                                                                                                 0.0s
 => => transferring context: 2B                                                                                                                                                   0.0s
 => [internal] load metadata for docker.io/library/ruby:2.6.5                                                                                                                     0.0s
 => [1/9] FROM docker.io/library/ruby:2.6.5                                                                                                                                       0.0s
 => [internal] load build context                                                                                                                                                 0.1s
 => => transferring context: 100.24kB                                                                                                                                             0.1s
 => CACHED [2/9] RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs                                                                                    0.0s
 => CACHED [3/9] RUN mkdir /myapp                                                                                                                                                 0.0s
 => CACHED [4/9] WORKDIR /myapp                                                                                                                                                   0.0s
 => CACHED [5/9] ADD Gemfile /myapp/Gemfile                                                                                                                                       0.0s
 => CACHED [6/9] ADD Gemfile.lock /myapp/Gemfile.lock                                                                                                                             0.0s
 => ERROR [7/9] RUN bundle update --bundler                                                                                                                                       3.6s
------                                                                                                                                                                                 
 > [7/9] RUN bundle update --bundler:                                                                                                                                                  
#11 0.524 Warning: the running version of Bundler (1.17.2) is older than the version that created the lockfile (1.17.3). We suggest you upgrade to the latest version of Bundler by running `gem install bundler`.                                                                                                                                                            
#11 2.072 Fetching gem metadata from https://rubygems.org/.........                                                                                                                    
#11 3.476 Your bundle is locked to mimemagic (0.3.3), but that version could not be found                                                                                              
#11 3.476 in any of the sources listed in your Gemfile. If you haven't changed sources,
#11 3.476 that means the author of mimemagic (0.3.3) has removed it. You'll need to update
#11 3.476 your bundle to a version other than mimemagic (0.3.3) that hasn't been removed
#11 3.476 in order to install.
------
executor failed running [/bin/sh -c bundle update --bundler]: exit code: 7
```

In addition, mimemagic had been contaminated with GPL-licensed software, making older versions unusable. Therefore, mimemagic has also been updated. The latest mimemagic does not depend on GPL-licensed software.
[Dependency on mimemagic 0.3.x no longer valid · Issue #41750 · rails/rails](https://github.com/rails/rails/issues/41750)