### PR TITLE
Skip gem install bundler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ RUN mkdir /myapp
 WORKDIR /myapp
 ADD Gemfile /myapp/Gemfile
 ADD Gemfile.lock /myapp/Gemfile.lock
-RUN gem install bundler -v 1.17.3
+# RUN gem install bundler -v 1.17.3 --no-document
 RUN bundle install
 ADD . /myapp

--- a/config/database.yml
+++ b/config/database.yml
@@ -18,7 +18,7 @@ mysql:
   database: development_railsgoat
   pool: 5
   timeout: 5000
-  host: localhost
+  host: mysql
   username: root
   password:
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,19 +1,18 @@
-# frozen_string_literal: true
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171007010129) do
+ActiveRecord::Schema.define(version: 2017_10_07_010129) do
 
-  create_table "analytics", force: :cascade do |t|
+  create_table "analytics", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.string "ip_address"
     t.string "referrer"
     t.string "user_agent"
@@ -21,19 +20,19 @@ ActiveRecord::Schema.define(version: 20171007010129) do
     t.datetime "updated_at"
   end
 
-  create_table "benefits", force: :cascade do |t|
+  create_table "benefits", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "key_managements", force: :cascade do |t|
+  create_table "key_managements", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.string "iv"
     t.integer "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "messages", force: :cascade do |t|
+  create_table "messages", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.integer "creator_id"
     t.integer "receiver_id"
     t.text "message"
@@ -42,7 +41,7 @@ ActiveRecord::Schema.define(version: 20171007010129) do
     t.datetime "updated_at"
   end
 
-  create_table "paid_time_offs", force: :cascade do |t|
+  create_table "paid_time_offs", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.integer "user_id"
     t.integer "sick_days_taken"
     t.integer "sick_days_earned"
@@ -52,7 +51,7 @@ ActiveRecord::Schema.define(version: 20171007010129) do
     t.datetime "updated_at"
   end
 
-  create_table "pays", force: :cascade do |t|
+  create_table "pays", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.integer "user_id"
     t.string "bank_account_num"
     t.string "bank_routing_num"
@@ -61,7 +60,7 @@ ActiveRecord::Schema.define(version: 20171007010129) do
     t.datetime "updated_at"
   end
 
-  create_table "performances", force: :cascade do |t|
+  create_table "performances", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.integer "user_id"
     t.date "date_submitted"
     t.integer "score"
@@ -71,7 +70,7 @@ ActiveRecord::Schema.define(version: 20171007010129) do
     t.datetime "updated_at"
   end
 
-  create_table "retirements", force: :cascade do |t|
+  create_table "retirements", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.string "total"
     t.string "employee_contrib"
     t.string "employer_contrib"
@@ -80,7 +79,7 @@ ActiveRecord::Schema.define(version: 20171007010129) do
     t.datetime "updated_at"
   end
 
-  create_table "schedules", force: :cascade do |t|
+  create_table "schedules", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.string "event_type"
     t.date "date_begin"
     t.date "date_end"
@@ -91,7 +90,7 @@ ActiveRecord::Schema.define(version: 20171007010129) do
     t.datetime "updated_at"
   end
 
-  create_table "users", force: :cascade do |t|
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.string "email"
     t.string "password"
     t.boolean "admin"
@@ -102,7 +101,7 @@ ActiveRecord::Schema.define(version: 20171007010129) do
     t.string "auth_token"
   end
 
-  create_table "work_infos", force: :cascade do |t|
+  create_table "work_infos", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.integer "user_id"
     t.string "income"
     t.string "bonuses"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,31 @@
 version: '2'
 services:
+  mysql:
+    image: mysql:5.7
+    restart: always
+    environment:
+      MYSQL_DATABASE: 'development_railsgoat'
+      MYSQL_ALLOW_EMPTY_PASSWORD: true
+    ports:
+      - '3306:3306'
+    expose:
+      - '3306'
+#    extra_hosts:
+#      - "host.docker.internal:host-gateway"
+
   web:
     build: .
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     volumes:
       - .:/myapp
+    environment:
+      RAILS_ENV: mysql
+      DB_USERNAME: root
+      DB_PASSWORD:
     ports:
       - "3000:3000"
+    depends_on:
+      - mysql
+    links:
+      - mysql
+

--- a/start-docker-compose-mysql.sh
+++ b/start-docker-compose-mysql.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -ex
+
+docker-compose build
+docker-compose run web bundle install
+docker-compose run web rails db:setup
+docker-compose run web rails db:migrate
+docker-compose up


### PR DESCRIPTION
I was still getting some installation errors, because (1) `gem install bundler` on Ruby 2.6.5 does not play well on an M2 Mac, (2) the install was taking forever, and (3) bundler 1.17.2 was already installed. I commented out the `gem install bundler` line.