### PR TITLE
Fix navbar alignment and font size toggle functionality

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -110,6 +110,13 @@
       margin-right: 0;
     }
 
+    /* Fix alignment of button_to forms in header */
+    .rg-header form {
+      margin: 0;
+      padding: 0;
+      display: inline-block;
+    }
+
     /* Modern Sidebar */
     .rg-sidebar {
       position: fixed;

--- a/app/views/layouts/shared/_header.html.erb
+++ b/app/views/layouts/shared/_header.html.erb
@@ -15,10 +15,10 @@
           <div class="d-flex align-items-center gap-3">
             <!-- Font Size Controls -->
             <div class="btn-group btn-group-sm" role="group" aria-label="Font size controls">
-              <a href="/dashboard/home?font=8pt" class="btn btn-outline-secondary" style="font-size: 10pt;" title="Small font" aria-label="Small font">
+              <a href="/dashboard/home?font=8pt" class="btn btn-outline-secondary" style="font-size: 10pt;" title="Small font" aria-label="Small font" data-turbolinks="false">
                 <i class="bi bi-type"></i>
               </a>
-              <a href="/dashboard/home?font=200%25" class="btn btn-outline-secondary" style="font-size: 14pt;" title="Large font" aria-label="Large font">
+              <a href="/dashboard/home?font=200%25" class="btn btn-outline-secondary" style="font-size: 14pt;" title="Large font" aria-label="Large font" data-turbolinks="false">
                 <i class="bi bi-type"></i>
               </a>
             </div>


### PR DESCRIPTION
## Summary

This PR fixes two UI issues in the navigation header that were discovered after PR #478 was merged.

## Changes

### 1. Navbar Alignment Issue
- **Issue**: The Tutorials button was slightly misaligned (positioned higher) compared to other navbar items like font size controls and the user dropdown
- **Root Cause**: `button_to` helper generates a `<form>` element which has default browser margins/padding
- **Solution**: Added CSS to remove margin/padding from forms within the header and set them to `display: inline-block`
- **File**: `app/views/layouts/application.html.erb`

### 2. Font Size Toggle Bug
- **Issue**: Clicking the small font button wouldn't apply changes until manual page refresh, while the large font button worked immediately
- **Root Cause**: Turbolinks was caching the page navigation, preventing the cookie from being set and CSS from being re-applied
- **Solution**: Added `data-turbolinks="false"` to both font size control links to force full page reload
- **File**: `app/views/layouts/shared/_header.html.erb`

## Testing

Tested locally:
- ✅ All navbar items (font controls, Tutorials button, user dropdown) are now properly aligned
- ✅ Small font button works immediately without manual refresh
- ✅ Large font button continues to work as before
- ✅ Both font size changes apply immediately on click

## Technical Details

The Turbolinks issue was subtle - it would cache the initial page load, so clicking a link to the same URL with different query params wouldn't trigger a full reload. This prevented the cookie-based font size preference from being set and applied. The `data-turbolinks="false"` attribute bypasses Turbolinks caching and forces a proper navigation with cookie setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)