### PR TITLE
Remove broken OWASP logo from hero section

### DIFF
--- a/index.html
+++ b/index.html
@@ -259,9 +259,6 @@
             </a>
           </div>
         </div>
-        <div class="col-lg-4 text-center mt-4 mt-lg-0">
-          <img src="img/owasp_175x45.jpg" alt="OWASP" class="img-fluid" style="max-width: 250px; filter: brightness(0) invert(1);">
-        </div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- Remove broken OWASP logo image that was displaying as a white rectangle in the hero section

## Changes
- Removed the entire column containing `img/owasp_175x45.jpg` from the hero section
- The image file doesn't exist and was rendering as a broken white rectangle on the live site

## Test Plan
- [x] Visit https://railsgoat.cktricky.com/ and verify the white rectangle is gone
- [x] Verify the hero section still looks good without the extra column

🤖 Generated with [Claude Code](https://claude.com/claude-code)