### PR TITLE
Replace vulnerability list with link to wiki as source of truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,21 +14,9 @@ RailsGoat is an intentionally insecure Rails application designed to teach web a
 
 ## Vulnerabilities Included
 
-RailsGoat includes examples of these security issues:
+RailsGoat demonstrates real-world security vulnerabilities from the OWASP Top 10, including SQL injection, cross-site scripting (XSS), authentication issues, insecure direct object references, and more.
 
-- **SQL Injection** - Unsafe database queries
-- **Cross-Site Scripting (XSS)** - Unescaped user input
-- **Cross-Site Request Forgery (CSRF)** - Missing request validation
-- **Insecure Direct Object Reference** - Unauthorized data access
-- **Mass Assignment** - Unprotected model attributes
-- **Authentication Issues** - Weak login mechanisms
-- **Sensitive Data Exposure** - Cleartext storage of SSNs and weak password hashing
-- **Missing Access Controls** - Unauthorized admin access
-- **Command Injection** - Unsafe system command execution
-- **Unvalidated Redirects** - Open redirect vulnerabilities
-- **Password Complexity Issues** - Insufficient password requirements
-
-Each vulnerability includes a failing test that demonstrates the security flaw and a wiki tutorial explaining the attack and remediation.
+For a complete list of vulnerabilities with detailed explanations and tutorials, visit the [RailsGoat Wiki](https://github.com/OWASP/railsgoat/wiki).
 
 ## Quick Start
 


### PR DESCRIPTION
This pull request updates the documentation in the `README.md` to streamline and modernize the description of included vulnerabilities. The list of vulnerabilities is now summarized, and readers are directed to the RailsGoat Wiki for full details and tutorials.

Documentation improvements:

* Simplified the description of included security vulnerabilities by summarizing them and removing the detailed bullet list.
* Added a link to the [RailsGoat Wiki](https://github.com/OWASP/railsgoat/wiki) for a complete list of vulnerabilities and tutorials, making the documentation easier to maintain and more user-friendly.