### PR TITLE
Fix remaining CSS selector and form field issues from UI/UX overhaul

### DIFF
--- a/spec/support/capybara_shared.rb
+++ b/spec/support/capybara_shared.rb
@@ -39,7 +39,7 @@ def login(user)
   visit "/"
   fill_in "email", with: user.email
   fill_in "password", with: user.clear_password
-  click_button "Login"
+  find("input[type='submit'][value='Login']").click
 end
 
 # Configure Selenium with headless Chrome for JavaScript testing

--- a/spec/vulnerabilities/broken_auth_spec.rb
+++ b/spec/vulnerabilities/broken_auth_spec.rb
@@ -14,26 +14,18 @@ feature "broken_auth" do
     wrong_email = normal_user.email + "not"
 
     visit "/"
-    within(".signup") do
-      fill_in "email", with: wrong_email
-      fill_in "password", with: normal_user.clear_password
-    end
-    within(".actions") do
-      click_on "Login"
-    end
+    fill_in "email", with: wrong_email
+    fill_in "password", with: normal_user.clear_password
+    find("input[type='submit'][value='Login']").click
 
     expect(find("div#flash_notice").text).not_to include(wrong_email)
   end
 
   scenario "two\nTutorial: https://github.com/OWASP/railsgoat/wiki/A2-Credential-Enumeration" do
     visit "/"
-    within(".signup") do
-      fill_in "email", with: normal_user.email
-      fill_in "password", with: normal_user.clear_password + "not"
-    end
-    within(".actions") do
-      click_on "Login"
-    end
+    fill_in "email", with: normal_user.email
+    fill_in "password", with: normal_user.clear_password + "not"
+    find("input[type='submit'][value='Login']").click
 
     expect(find("div#flash_notice").text).not_to include("Incorrect Password!")
   end

--- a/spec/vulnerabilities/password_complexity_spec.rb
+++ b/spec/vulnerabilities/password_complexity_spec.rb
@@ -13,14 +13,12 @@ feature "password complexity" do
     new_user_email = normal_user.email + "two"
 
     visit "/signup"
-    within(".signup") do
-      fill_in "user_email", with: new_user_email
-      fill_in "user_first_name", with: normal_user.first_name
-      fill_in "user_last_name", with: normal_user.last_name + "not"
-      fill_in "user_password", with: "password"
-      fill_in "user_password_confirmation", with: "password"
-    end
-    click_on "Submit"
+    fill_in "email", with: new_user_email
+    fill_in "first_name", with: normal_user.first_name
+    fill_in "last_name", with: normal_user.last_name + "not"
+    fill_in "password", with: "password"
+    fill_in "password_confirmation", with: "password"
+    click_on "Create Account"
 
     expect(User.find_by(email: new_user_email)).to be_nil
     expect(current_path).to eq("/signup")

--- a/spec/vulnerabilities/unvalidated_redirects_spec.rb
+++ b/spec/vulnerabilities/unvalidated_redirects_spec.rb
@@ -12,13 +12,9 @@ feature "unvalidated redirect" do
 
   scenario "attack\nTutorial: https://github.com/OWASP/railsgoat/wiki/A10-Unvalidated-Redirects-and-Forwards-(redirect_to)", js: true do
     visit "/?url=http://example.com/do/evil/things"
-    within(".signup") do
-      fill_in "email", with: normal_user.email
-      fill_in "password", with: normal_user.clear_password
-    end
-    within(".actions") do
-      click_on "Login"
-    end
+    fill_in "email", with: normal_user.email
+    fill_in "password", with: normal_user.clear_password
+    find("input[type='submit'][value='Login']").click
 
     expect(current_url).to start_with("http://127.0.0.1")
     expect(current_path).to eq("/dashboard/home")


### PR DESCRIPTION
## Summary

This PR addresses the remaining test failures @jasnow reported in issue #486 after PR #487 was merged.

## Issues Fixed

### 1. Ambiguous Login Button Error

**Problem:** Tests were failing with "Ambiguous match, found 2 elements matching visible button 'Login'"

**Root Cause:** The new UI has TWO "Login" buttons:
- Form submit button: `<input type="submit" value="Login">`  
- Header navigation button (for unauth users)

**Solution:** Changed from `click_button "Login"` to `find("input[type='submit'][value='Login']").click` to specifically target the form submit button

**Files Changed:**
- `spec/support/capybara_shared.rb` - Updated `login` helper
- `spec/vulnerabilities/broken_auth_spec.rb` - Both scenarios
- `spec/vulnerabilities/unvalidated_redirects_spec.rb`

### 2. Password Complexity Spec Field Names

**Problem:** Test failing with "Unable to find field 'user_email'"

**Root Cause:** The signup form uses `form_for @user` which generates field IDs without the `user_` prefix

**Solution:** Updated field names to match the actual form:
- `user_email` → `email`
- `user_first_name` → `first_name`
- `user_last_name` → `last_name`
- `user_password` → `password`
- `user_password_confirmation` → `password_confirmation`
- `Submit` → `Create Account` (correct button text)

**Files Changed:**
- `spec/vulnerabilities/password_complexity_spec.rb`

## Testing

Ran the affected specs in maintainer mode:
```bash
RAILSGOAT_MAINTAINER="yes" bundle exec rspec \
  spec/vulnerabilities/broken_auth_spec.rb \
  spec/vulnerabilities/password_complexity_spec.rb \
  spec/vulnerabilities/unvalidated_redirects_spec.rb
```

All specs now pass (showing as "pending" which is correct - they demonstrate the vulnerabilities working as expected).

## Related

- Closes #486
- Follow-up to #487