### PR TITLE
Fix RSpec 3 compatibility: Replace pending with skip

### DIFF
--- a/spec/vulnerabilities/broken_auth_spec.rb
+++ b/spec/vulnerabilities/broken_auth_spec.rb
@@ -7,7 +7,7 @@ feature "broken_auth" do
   before do
     UserFixture.reset_all_users
 
-    pending unless verifying_fixed?
+    skip unless verifying_fixed?
   end
 
   scenario "one\nTutorial: https://github.com/OWASP/railsgoat/wiki/A2-Credential-Enumeration" do

--- a/spec/vulnerabilities/command_injection_spec.rb
+++ b/spec/vulnerabilities/command_injection_spec.rb
@@ -7,7 +7,7 @@ feature "command injection" do
 
   before do
     UserFixture.reset_all_users
-    pending unless verifying_fixed?
+    skip unless verifying_fixed?
   end
 
   scenario "attack\nTutorial: https://github.com/OWASP/railsgoat/wiki/A1-Command-Injection", js: true do

--- a/spec/vulnerabilities/csrf_spec.rb
+++ b/spec/vulnerabilities/csrf_spec.rb
@@ -7,7 +7,7 @@ feature "csrf" do
 
   before(:each) do
     UserFixture.reset_all_users
-    pending unless verifying_fixed?
+    skip unless verifying_fixed?
   end
 
   scenario "attack\nTutorial: https://github.com/OWASP/railsgoat/wiki/R4-A8-CSRF", js: true do

--- a/spec/vulnerabilities/insecure_dor_spec.rb
+++ b/spec/vulnerabilities/insecure_dor_spec.rb
@@ -7,7 +7,7 @@ feature "insecure direct object reference" do
 
   before do
     UserFixture.reset_all_users
-    pending unless verifying_fixed?
+    skip unless verifying_fixed?
   end
 
   scenario "attack one" do

--- a/spec/vulnerabilities/mass_assignment_spec.rb
+++ b/spec/vulnerabilities/mass_assignment_spec.rb
@@ -6,7 +6,7 @@ feature "mass assignment" do
 
   before do
     UserFixture.reset_all_users
-    pending unless verifying_fixed?
+    skip unless verifying_fixed?
   end
 
   scenario "attack one" do

--- a/spec/vulnerabilities/password_complexity_spec.rb
+++ b/spec/vulnerabilities/password_complexity_spec.rb
@@ -6,7 +6,7 @@ feature "password complexity" do
 
   before do
     UserFixture.reset_all_users
-    pending unless verifying_fixed?
+    skip unless verifying_fixed?
   end
 
   scenario "one\nTutorial: https://github.com/OWASP/railsgoat/wiki/A2-Lack-of-Password-Complexity" do

--- a/spec/vulnerabilities/sensitive_data_exposure.rb
+++ b/spec/vulnerabilities/sensitive_data_exposure.rb
@@ -9,7 +9,7 @@ feature "sensitive data exposure" do
     UserFixture.reset_all_users
     normal_user.work_info.update(:SSN, user_ssn)
 
-    pending unless verifying_fixed?
+    skip unless verifying_fixed?
   end
 
   # this won't work with javascript_driver, as it'll apply the javascript

--- a/spec/vulnerabilities/sql_injection_spec.rb
+++ b/spec/vulnerabilities/sql_injection_spec.rb
@@ -7,7 +7,7 @@ feature "sql injection" do
 
   before do
     UserFixture.reset_all_users
-    pending unless verifying_fixed?
+    skip unless verifying_fixed?
   end
 
   scenario "attack\nTutorial: https://github.com/OWASP/railsgoat/wiki/R5-A1-SQL-Injection-Concatentation" do

--- a/spec/vulnerabilities/unvalidated_redirects_spec.rb
+++ b/spec/vulnerabilities/unvalidated_redirects_spec.rb
@@ -7,7 +7,7 @@ feature "unvalidated redirect" do
   before do
     UserFixture.reset_all_users
 
-    pending unless verifying_fixed?
+    skip unless verifying_fixed?
   end
 
   scenario "attack\nTutorial: https://github.com/OWASP/railsgoat/wiki/A10-Unvalidated-Redirects-and-Forwards-(redirect_to)", js: true do

--- a/spec/vulnerabilities/url_access_spec.rb
+++ b/spec/vulnerabilities/url_access_spec.rb
@@ -7,7 +7,7 @@ feature "url access" do
   before do
     UserFixture.reset_all_users
 
-    pending unless verifying_fixed?
+    skip unless verifying_fixed?
   end
 
   scenario "attack\nTutorial: https://github.com/OWASP/railsgoat/wiki/A7-Missing-Function-Level-Access-Control--(Admin-Controller)", js: true do

--- a/spec/vulnerabilities/xss_spec.rb
+++ b/spec/vulnerabilities/xss_spec.rb
@@ -7,7 +7,7 @@ feature "xss" do
   before(:each) do
     UserFixture.reset_all_users
 
-    pending unless verifying_fixed?
+    skip unless verifying_fixed?
   end
 
   scenario "attack\nTutorial: https://github.com/OWASP/railsgoat/wiki/A3-Cross-Site-Scripting", js: true do


### PR DESCRIPTION
## Summary

Fixes RSpec 3 compatibility issue by replacing `pending` with `skip` in vulnerability specs to align with modern RSpec semantics.

## Problem

In RSpec 2, `pending` would skip tests. In RSpec 3+, `pending` changed to mean "this test is expected to fail, and if it passes, that's an error." This was causing false failures in maintainer mode when tests passed.

Reference: https://rspec.info/blog/2014/05/notable-changes-in-rspec-3

## Solution

Replaced `pending unless verifying_fixed?` with `skip unless verifying_fixed?` in all 11 vulnerability spec files.

## Files Changed

- `spec/vulnerabilities/broken_auth_spec.rb`
- `spec/vulnerabilities/command_injection_spec.rb`
- `spec/vulnerabilities/csrf_spec.rb`
- `spec/vulnerabilities/insecure_dor_spec.rb`
- `spec/vulnerabilities/mass_assignment_spec.rb`
- `spec/vulnerabilities/password_complexity_spec.rb`
- `spec/vulnerabilities/sensitive_data_exposure.rb`
- `spec/vulnerabilities/sql_injection_spec.rb`
- `spec/vulnerabilities/unvalidated_redirects_spec.rb`
- `spec/vulnerabilities/url_access_spec.rb`
- `spec/vulnerabilities/xss_spec.rb`

## Testing

✅ Ran full test suite in maintainer mode: **46 examples, 0 failures, 13 pending**

The tests now properly skip in maintainer mode (shown as pending) without causing false failures.

## Behavior

- **Maintainer mode** (`RAILSGOAT_MAINTAINER=true`): Vulnerability tests are skipped
- **Training mode** (default): Vulnerability tests run and demonstrate security flaws

🤖 Generated with [Claude Code](https://claude.com/claude-code)